### PR TITLE
setup release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,31 +1,62 @@
 name: Release
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - v*
 
 jobs:
   release-vsix:
-    name: Release VSIX Artifact
+    name: Release & Publish
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
+      - name: Clone repository
         uses: actions/checkout@v3
 
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
 
       - name: Install dependencies
         run: npm install
 
-      - name: Package VSIX
-        run: npm run package
+      - name: Obtain release version
+        id: release_version
+        run: |
+          TAGGED_VERSION="${GITHUB_REF/refs\/tags\/v/}"
+          
+          if [[ ! "${TAGGED_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
+            echo "Invalid version tag '${TAGGED_VERSION}'"
+            exit 1
+          fi
+          
+          echo "EXT_VERSION=${TAGGED_VERSION}" >> $GITHUB_ENV
+          WRITTEN_VERSION="$(cat package.json | jq '.version' -r)"
+          
+          if [[ "${TAGGED_VERSION}" == *"-"* ]]; then
+            if [[ ! "${TAGGED_VERSION}" == "${WRITTEN_VERSION}"-rc.* ]]; then
+              echo "pre-release tag and version in package.json are not compatible: '${TAGGED_VERSION}' vs '${WRITTEN_VERSION}'"
+              exit 1
+            fi
+            echo "EXT_ISPREVIEW=1" >> $GITHUB_ENV
+          else
+            if [[ "${TAGGED_VERSION}" != "${WRITTEN_VERSION}" ]]; then
+              echo "release tag and version in package.json do not match: '${TAGGED_VERSION}' vs '${WRITTEN_VERSION}'"
+              exit 1
+            fi
+            echo "EXT_ISPREVIEW=0" >> $GITHUB_ENV
+          fi
 
-      - name: Upload VSIX to Release
+      - name: Package VSIX
+        run: vsce package -o "./coco-${{ env.EXT_VERSION }}.vsix"
+
+      - name: Upload VSIX to Release Assets
         uses: softprops/action-gh-release@v1
         if: ${{startsWith(github.ref, 'refs/tags/') }}
         with:
-          files: coco.vsix
+          name: Release ${{ env.EXT_VERSION }}
+          files: coco-${{ env.EXT_VERSION }}.vsix
+
+      # todo: publish to vs code marketplace

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,7 @@ jobs:
   release-vsix:
     name: Release & Publish
     runs-on: ubuntu-latest
+    if: github.repository == 'sarvalabs/vscode-coco'
 
     steps:
       - name: Clone repository
@@ -61,4 +62,6 @@ jobs:
           files: coco-${{ env.EXT_VERSION }}.vsix
           prerelease: ${{env.EXT_ISPREVIEW == 1}}
 
-      # todo: publish to vs code marketplace
+      - name: Publish to VS Code Extension Marketplace
+        if: env.EXT_ISPREVIEW != 1 && github.repository == 'sarvalabs/vscode-coco'
+        run: npx vsce publish -i "./coco-${{ env.EXT_VERSION }}.vsix" -p "${{ secrets.VSCE_TOKEN }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,8 @@
 name: Release
 
 on:
-  release: [published]
+  release:
+    types: [published]
 
 jobs:
   release-vsix:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  release: [published]
+
+jobs:
+  release-vsix:
+    name: Release VSIX Artifact
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Package VSIX
+        run: npm run package
+
+      - name: Upload VSIX to Release
+        uses: softprops/action-gh-release@v1
+        if: ${{startsWith(github.ref, 'refs/tags/') }}
+        with:
+          files: coco.vsix

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,9 +18,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '18'
+          cache: 'npm'
 
       - name: Install dependencies
-        run: npm install && npm install --only=dev
+        run: npm install
 
       - name: Obtain release version
         id: release_version
@@ -50,7 +51,7 @@ jobs:
           fi
 
       - name: Package VSIX
-        run: vsce package -o "./coco-${{ env.EXT_VERSION }}.vsix"
+        run: npx vsce package -o "./coco-${{ env.EXT_VERSION }}.vsix"
 
       - name: Upload VSIX to Release Assets
         uses: softprops/action-gh-release@v1
@@ -58,5 +59,6 @@ jobs:
         with:
           name: Release ${{ env.EXT_VERSION }}
           files: coco-${{ env.EXT_VERSION }}.vsix
+          prerelease: ${{env.EXT_ISPREVIEW == 1}}
 
       # todo: publish to vs code marketplace

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
           node-version: '18'
 
       - name: Install dependencies
-        run: npm install
+        run: npm install && npm install --only=dev
 
       - name: Obtain release version
         id: release_version

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [latestrelease]: https://github.com/sarvalabs/vscode-coco/releases/latest
 [issueslink]: https://github.com/sarvalabs/vscode-coco/issues
+[marketplace]: https://marketplace.visualstudio.com/items?itemName=sarvalabs.cocolang
 
 [![license](https://img.shields.io/badge/license-MIT-informational?style=for-the-badge)](./LICENSE)
 [![latest tag](https://img.shields.io/github/v/tag/sarvalabs/vscode-coco?color=blue&label=latest%20tag&sort=semver&style=for-the-badge)][latestrelease]
@@ -11,8 +12,7 @@
 The VS Code Cocolang extension provides syntax highlighting for the [Coco programming language](http://cocolang.dev).
 
 ### Install from the Extension Marketplace
-Currently, the extension must be manually installed to VS Code using a `.vsix` file.  
-We are actively working to publish this extension on the Visual Studio Code Marketplace.
+This extension can be installed from the Visual Studio Code Extension Marketplace [here][marketplace].
 
 ### Install from a VSIX
 A `.vsix` files comes bundled with every release and can be downloaded from [here][latestrelease].  

--- a/README.md
+++ b/README.md
@@ -5,46 +5,31 @@
 
 [![license](https://img.shields.io/badge/license-MIT-informational?style=for-the-badge)](./LICENSE)
 [![latest tag](https://img.shields.io/github/v/tag/sarvalabs/vscode-coco?color=blue&label=latest%20tag&sort=semver&style=for-the-badge)][latestrelease]
+![minver_vscode](https://img.shields.io/badge/vs_code-^v0.1.59-informational?style=for-the-badge&color=purple)
 [![issue count](https://img.shields.io/github/issues/sarvalabs/vscode-coco?style=for-the-badge&color=yellow)][issueslink]
 
 The VS Code Coco extension provides syntax highlighting for the [Coco programming language](http://cocolang.dev).
 
-**NOTE**: Currently, it must be manually installed using a `.vsix` file. We are actively working to publish this
-extension on the Visual Studio Code Marketplace.
+### Install from the Extension Marketplace
+Currently, the extension must be manually installed to VS Code using a `.vsix` file.  
+We are actively working to publish this extension on the Visual Studio Code Marketplace.
 
-### Requirements
-- [Visual Studio Code](https://code.visualstudio.com/download) (v0.1.59 or greater)
+### Install from a VSIX
+A `.vsix` files comes bundled with every release and can be downloaded from [here][latestrelease].  
 
-### Installation
-Install the extension manually with the `.vsix` file available in the releases.
+Alternatively, it can be built from this repository source with the following command (requires NPM) 
+resulting in the creation of a file named a file `coco-v*.*.*.vsix` with the release version.
+```bash
+npm run package
+```
 
-1. Download the latest release of the Coco extension from the [releases](https://github.com/sarvalabs/vscode-coco/releases)
-2. Open Visual Studio Code.
-3. In Visual Studio Code, go to the Extensions View by clicking on the Extensions icon in the Activity Bar on the side 
-of the window or using the shortcut `Ctrl+Shift+X` (Windows/Linux) or `Cmd+Shift+X` (Mac).
-4. Click on the three dots menu icon (⋮) in the Extensions View's top-right corner, and select "Install from VSIX."
-5. Browse to the location where you downloaded the Coco VSIX extension `.vsix` file, select it, and click "Open."
-6. The Coco extension will now be installed in Visual Studio Code.
+However, you obtain the `.vsix` file, it can then be used to install the extension to Visual Studio
+Code using the following command. Read more [here](https://code.visualstudio.com/docs/editor/extension-marketplace#_install-from-a-vsix) 
+for other ways to install from a VSIX 
+```bash
+code --install-extension coco.vsix
+```
 
-### Using the Extension
-To use the Coco extension, follow these steps:
-
-1. Open a project or file in Visual Studio Code that is relevant to the functionality provided by the extension.
-2. The Coco extension should automatically start working if it has any features that apply to the current project 
-or file. Otherwise, you may need to trigger the extension manually by interacting with its commands, settings, or 
-other integration points.
-3. Refer to the extension's documentation or the README file of the Coco extension's GitHub repository to learn 
-about its specific features and how to use them effectively.
-
-### Uninstalling the Extension
-If you want to uninstall the Coco extension, follow these steps:
-
-1. Open Visual Studio Code.
-2. Go to the Extensions View by clicking on the Extensions icon in the Activity Bar on the side of the window or
-using the shortcut `Ctrl+Shift+X` (Windows/Linux) or `Cmd+Shift+X` (Mac).
-3. Find the installed Coco extension in the Extensions View.
-4. Click on the gear icon next to the Coco extension's name and select "Uninstall."
-5. Confirm the uninstallation when prompted.
 
 ### Feedback and Issues
 If you encounter any issues with the Coco extension or have suggestions for improvements, please check 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Coco for Visual Studio Code
+# Cocolang for Visual Studio Code
 
 [latestrelease]: https://github.com/sarvalabs/vscode-coco/releases/latest
 [issueslink]: https://github.com/sarvalabs/vscode-coco/issues
@@ -8,7 +8,7 @@
 ![minver_vscode](https://img.shields.io/badge/vs_code-^v0.1.59-informational?style=for-the-badge&color=purple)
 [![issue count](https://img.shields.io/github/issues/sarvalabs/vscode-coco?style=for-the-badge&color=yellow)][issueslink]
 
-The VS Code Coco extension provides syntax highlighting for the [Coco programming language](http://cocolang.dev).
+The VS Code Cocolang extension provides syntax highlighting for the [Coco programming language](http://cocolang.dev).
 
 ### Install from the Extension Marketplace
 Currently, the extension must be manually installed to VS Code using a `.vsix` file.  
@@ -32,6 +32,6 @@ code --install-extension coco.vsix
 
 
 ### Feedback and Issues
-If you encounter any issues with the Coco extension or have suggestions for improvements, please check 
-the extension's [GitHub repository](https://github.com/sarvalabs/vscode-coco) for issue tracking. 
+If you encounter any issues with the Cocolang extension or have suggestions for improvements, please 
+check the extension's [GitHub repository](https://github.com/sarvalabs/vscode-coco) for issue tracking.
 You can open a new issue to report problems or submit feature requests.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Coco for Visual Studio Code
 
-![license](https://img.shields.io/badge/license-MIT-informational?style=for-the-badge)
-![latest tag](https://img.shields.io/github/v/tag/sarvalabs/vscode-coco?color=blue&label=latest%20tag&sort=semver&style=for-the-badge)
-![issue count](https://img.shields.io/github/issues/sarvalabs/vscode-coco?style=for-the-badge&color=yellow)
+[latestrelease]: https://github.com/sarvalabs/vscode-coco/releases/latest
+[issueslink]: https://github.com/sarvalabs/vscode-coco/issues
+
+[![license](https://img.shields.io/badge/license-MIT-informational?style=for-the-badge)](./LICENSE)
+[![latest tag](https://img.shields.io/github/v/tag/sarvalabs/vscode-coco?color=blue&label=latest%20tag&sort=semver&style=for-the-badge)][latestrelease]
+[![issue count](https://img.shields.io/github/issues/sarvalabs/vscode-coco?style=for-the-badge&color=yellow)][issueslink]
 
 The VS Code Coco extension provides syntax highlighting for the [Coco programming language](http://cocolang.dev).
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     },
     "scripts": {
         "clean": "rm -rf ./dist/* && rm *.vsix",
-        "package": "vsce package -o coco.vsix"
+        "package": "vsce package"
     },
     "devDependencies": {
         "@vscode/vsce": "^2.19.0"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "Syntax Highlighting for Cocolang on Visual Studio Code",
     "version": "0.0.1",
     "license": "MIT",
+    "publisher": "sarvalabs",
     "author": {
         "name": "Coco Team at Sarva Labs"
     },

--- a/package.json
+++ b/package.json
@@ -21,9 +21,7 @@
         "node": ">=12.0.0"
     },
     "categories": [
-        "Plugins",
-        "Syntax Highlighting",
-        "Programming Languages"
+        "Programming Languages",
     ],
     "contributes": {
         "languages": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "coco",
     "displayName": "Coco",
     "description": "Syntax Highlighting for Cocolang on Visual Studio Code",
-    "version": "0.1.0",
+    "version": "0.0.1",
     "license": "MIT",
     "author": {
         "name": "Coco Team at Sarva Labs"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "node": ">=12.0.0"
     },
     "categories": [
-        "Programming Languages",
+        "Programming Languages"
     ],
     "contributes": {
         "languages": [

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
-    "name": "coco",
-    "displayName": "Coco",
+    "name": "cocolang",
+    "displayName": "Cocolang",
+    "icon": "icons/coco.png",
     "description": "Syntax Highlighting for Cocolang on Visual Studio Code",
     "version": "0.0.1",
     "license": "MIT",
     "publisher": "sarvalabs",
     "author": {
-        "name": "Coco Team at Sarva Labs"
+        "name": "Cocolang Team at Sarva Labs"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
This PR sets up the release workflow for this VS Code Extension.
- Updated the README with more badges with fixed links. It removes the exhaustive install instructions.
- Added a GitHub Action release workflow that is triggered on the push to a semantic version tag
    - Verifies the tag integrity with `package.json`  file. (must match for a stable release and match the primary version for pre-release tags which must have the structure of `v*.*.*-rc.*`)
    - Packages the extension as a VSIX file labelled with the release version
    - Creates a Release and uploads the VSIX file to the release
    - [todo] Publish to the VS Code Extension Marketplace

**Note**: If the Marketplace can be setup within this PR, the README needs to be updated as well