### PR TITLE
enhancement: new keywords and syntax support

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "Cocolang",
     "icon": "icons/coco.png",
     "description": "Syntax Highlighting for Cocolang on Visual Studio Code",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "license": "MIT",
     "publisher": "sarvalabs",
     "author": {

--- a/syntaxes/coco.tmLanguage.json
+++ b/syntaxes/coco.tmLanguage.json
@@ -191,7 +191,7 @@
                 },
                 {
                     "comment": "Supporting functions",
-                    "match": "\\b(append|popend|haskey|merge|polorize|depolorize)\\b(?=\\()",
+                    "match": "\\b(append|popend|merge)\\b(?=\\()",
                     "name": "support.function.builtin.coco"
                 }
             ]
@@ -206,7 +206,7 @@
                 {
                     "comment": "Action Keywords",
                     "name": "keyword.action.coco",
-                    "match": "\\b(observe|transfer|polorize|depolorize)\\b"
+                    "match": "\\b(observe|transfer)\\b"
                 },
                 {
                     "comment": "Exception Handling",
@@ -236,7 +236,12 @@
                 {
                     "comment": "Crypto Builtins",
                     "name": "keyword.builtins.coco",
-                    "match": "\\b(Blake2b|Keccak256|Sha256)\\b"
+                    "match": "\\b(blake2b|keccak256|sha256|sigverify)\\b"
+                },
+                {
+                    "comment": "Serial Builtins",
+                    "name": "keyword.builtins.coco",
+                    "match": "\\b(polorize|depolorize)\\b"
                 },
                 {
                     "comment": "Special Methods",

--- a/syntaxes/coco.tmLanguage.json
+++ b/syntaxes/coco.tmLanguage.json
@@ -230,7 +230,7 @@
                 },
                 {
                     "comment": "State Keyword",
-                    "name": "keyword.state.coco",
+                    "name": "keyword.state.accessor.coco",
                     "match": "\\b(state)\\b"
                 },
                 {

--- a/syntaxes/coco.tmLanguage.json
+++ b/syntaxes/coco.tmLanguage.json
@@ -236,7 +236,12 @@
                 {
                     "comment": "Crypto Builtins",
                     "name": "keyword.builtins.coco",
-                    "match": "\\b(Blake2b|Keccak256|len|Sha256)\\b"
+                    "match": "\\b(Blake2b|Keccak256|Sha256)\\b"
+                },
+                {
+                    "comment": "Special Methods",
+                    "name": "keyword.special.coco",
+                    "match": "\\b(len|join)\\b"
                 }
             ]
         },

--- a/syntaxes/coco.tmLanguage.json
+++ b/syntaxes/coco.tmLanguage.json
@@ -455,7 +455,7 @@
                 {
                     "comment": "Variable Declaration",
                     "name": "variable.declaration.coco",
-                    "match": "\\b(var)\\b\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s+([a-zA-Z_][a-zA-Z0-9_]*\\b)?",
+                    "match": "\\b(var)\\b\\s+((?:[a-zA-Z_][a-zA-Z0-9_]*\\s*,\\s*)*[a-zA-Z_][a-zA-Z0-9_]*)\\s+([a-zA-Z_][a-zA-Z0-9_]+\\b)?",
                     "captures": {
                         "1": {
                             "name": "keyword.var.coco"

--- a/syntaxes/coco.tmLanguage.json
+++ b/syntaxes/coco.tmLanguage.json
@@ -39,7 +39,7 @@
             "include": "#methods"
         },
         {
-            "include": "#mutate"
+            "include": "#state_access"
         },
         {
             "include": "#operators"
@@ -272,14 +272,14 @@
                 }
             ]
         },
-        "mutate": {
+        "state_access": {
             "patterns": [
                 {
-                    "comment": "Open/Closed Mutate Statement",
-                    "match": "\\b(mutate)\\b|(<-|->)\\s*|([A-Za-z_][A-Za-z0-9_]*)\\.(State|Sender|Receiver)\\s*",
+                    "comment": "Open/Closed State Access Statement",
+                    "match": "\\b(mutate|observe)\\b|(<-|->)\\s*|([A-Za-z_][A-Za-z0-9_]*)\\.(State|Sender|Receiver)\\s*",
                     "captures": {
                         "1": {
-                            "name": "keyword.mutate.coco"
+                            "name": "keyword.state.coco"
                         },
                         "2": {
                             "name": "keyword.operator.assignment.coco"
@@ -325,6 +325,11 @@
                     "comment": "Logical Operators",
                     "match": "(&&|\\|\\||!)",
                     "name": "keyword.operator.logical.coco"
+                },
+                {
+                    "comment": "Inclusivity Operator",
+                    "match": "\\?(?=(?:[^'\"]|\"[^\"]*\"|'[^']*')*$)",
+                    "name": "keyword.operator.inclusivity.coco"
                 }
             ]
         },

--- a/syntaxes/coco.tmLanguage.json
+++ b/syntaxes/coco.tmLanguage.json
@@ -201,7 +201,7 @@
                 {
                     "comment": "Control Keywords",
                     "name": "keyword.control.coco",
-                    "match": "\\b(if|elif|else|for|break|pass|continue|return|yield|from|in)\\b"
+                    "match": "\\b(if|else|for|break|pass|continue|return|yield|from|in)\\b"
                 },
                 {
                     "comment": "Action Keywords",

--- a/syntaxes/coco.tmLanguage.json
+++ b/syntaxes/coco.tmLanguage.json
@@ -18,6 +18,9 @@
             "include": "#contract_name"
         },
         {
+            "include": "#endpoints"
+        },
+        {
             "include": "#exceptions"
         },
         {
@@ -126,6 +129,25 @@
                 }
             ]
         },
+        "endpoints": {
+            "patterns": [
+                {
+                    "comment": "Callable Endpoints",
+                    "match": "^(endpoint)\\s+(invokable|deployer)\\s+(\\w+!?)\\(",
+                    "captures": {
+                        "1": {
+                            "name": "keyword.function.coco"
+                        },
+                        "2": {
+                            "name": "storage.modifier.func.coco"
+                        },
+                        "3": {
+                            "name": "entity.name.function.coco"
+                        }
+                    }
+                }
+            ]
+        },
         "exceptions": {
             "patterns": [
                 {
@@ -157,13 +179,10 @@
             "patterns": [
                 {
                     "comment": "Function declarations",
-                    "match": "^(func)\\s+(?:(invokable|deployer|local)\\s+)?(\\w+!?)\\(",
+                    "match": "^(func)\\s+(?:()\\s+)?(\\w+!?)\\(",
                     "captures": {
                         "1": {
                             "name": "keyword.function.coco"
-                        },
-                        "2": {
-                            "name": "storage.modifier.func.coco"
                         },
                         "3": {
                             "name": "entity.name.function.coco"


### PR DESCRIPTION
# Description
- callable functions are now renamed to endpoints
- 'local' is no longer a function modifier keyword
- 'func' by default now denotes a locally callable function
- 'elif 'support is dropped, 'else if' must be used in conditional statements
- 'join' and 'len' are now special method keywords
- var is now fixed to allow multiple named variables of same type in one line
- version updated to 0.1.1

# Changes include
-  New feature (non-breaking change that adds functionality)

# Checklist

- I have assigned this PR to myself
- I have added at least 1 reviewer
- I have tested this code

