### PR TITLE
feature: add multiline support

### DIFF
--- a/syntaxes/coco.tmLanguage.json
+++ b/syntaxes/coco.tmLanguage.json
@@ -430,13 +430,15 @@
                     ]
                 },
                 {
-                    "name": "constant.character.escape.coco",
-                    "match": "\\\\."
-                },
-                {
                     "name": "string.quoted.double.coco",
                     "begin": "\"",
-                    "end": "\""
+                    "end": "\"",
+                    "patterns": [
+                        {
+                            "name": "constant.character.escape.coco",
+                            "match": "\\\\."
+                        }
+                    ]
                 }
             ]
         },

--- a/syntaxes/coco.tmLanguage.json
+++ b/syntaxes/coco.tmLanguage.json
@@ -402,29 +402,30 @@
                     "patterns": [
                         {
                             "name": "string.quoted.other.multiline.coco",
-                            "begin": "f\"",
-                            "end": "\"",
+                            "begin": "{",
+                            "end": "}",
                             "patterns": [
                                 {
-                                    "name": "embedded-expression",
-                                    "begin": "\\{",
-                                    "end": "\\}",
-                                    "patterns": [
-                                        {
-                                            "include": "source.coco"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "name": "punctuation.other.bracket.curly.coco",
-                                    "match": "\\{|\\}"
-                                },
-                                {
-                                    "match": "(?=\")",
-                                    "name": "string.quoted.other.multiline.coco",
-                                    "pop": true
+                                    "include": "source.coco"
                                 }
                             ]
+                        },
+                        {
+                            "name": "punctuation.other.bracket.curly.coco",
+                            "match": "\\{|\\}"
+                        },
+                        {
+                            "match": "[^\"{\\\\}]+|\\{",
+                            "name": "string.quoted.other.multiline.coco"
+                        },
+                        {
+                            "match": "\\\\.",
+                            "name": "constant.character.escape.coco"
+                        },
+                        {
+                            "match": "(?=\")",
+                            "name": "string.quoted.other.multiline.coco",
+                            "pop": true
                         }
                     ]
                 },


### PR DESCRIPTION
## Description
- This PR adds support for the '\' character within strings and f-strings
- This now allows the character after '\' to be ignored within strings and f-strings

## Changes include
- New Feature (non-breaking change that adds functionality)


