### PR TITLE
feature: add support for cocolang v0.5.0

### DIFF
--- a/server/src/modules/completion.ts
+++ b/server/src/modules/completion.ts
@@ -21,54 +21,69 @@ export const completionItems = (): CompletionItem[] => {
 			data: 3
 		},
 		{
-			label: 'deployer',
+			label: 'deploy',
 			kind: CompletionItemKind.Text,
 			data: 4
 		},
 		{
-			label: 'invokable',
+			label: 'invoke',
 			kind: CompletionItemKind.Text,
 			data: 5
 		},
 		{
-			label: 'endpoint',
+			label: 'enlist',
 			kind: CompletionItemKind.Text,
 			data: 6
 		},
 		{
-			label: 'state',
+			label: 'endpoint',
 			kind: CompletionItemKind.Text,
 			data: 7
 		},
 		{
-			label: 'persistent',
+			label: 'state',
 			kind: CompletionItemKind.Text,
 			data: 8
 		},
 		{
-			label: 'class',
+			label: 'persistent',
 			kind: CompletionItemKind.Text,
 			data: 9
 		},
 		{
-			label: 'method',
+			label: 'ephemeral',
 			kind: CompletionItemKind.Text,
 			data: 10
 		},
 		{
-			label: 'coco',
+			label: 'readonly',
 			kind: CompletionItemKind.Text,
 			data: 11
 		},
 		{
-			label: 'var',
+			label: 'class',
 			kind: CompletionItemKind.Text,
 			data: 12
 		},
 		{
-			label: 'const',
+			label: 'method',
 			kind: CompletionItemKind.Text,
 			data: 13
+		},
+		{
+			label: 'coco',
+			kind: CompletionItemKind.Text,
+			data: 14
+		},
+		{
+			label: 'var',
+			kind: CompletionItemKind.Text,
+			data: 15
+		},
+		{
+			label: 'const',
+			kind: CompletionItemKind.Text,
+			data: 16
 		},
 	]
 }
@@ -96,34 +111,46 @@ export const completionDetails = (item: CompletionItem): CompletionItem => {
 			item.documentation = 'Invokables are endpoints that can only be invoked externally by a single participant. ';
 			break;
 		case 6:
+			item.detail = 'enlister declaration';
+			item.documentation = 'Enlisters are endpoints that can only be invoked externally and affect the ephemeral state';
+			break;
+		case 7:
 			item.detail = 'endpoint declaration';
 			item.documentation = 'A endpoint in Coco is a callable element for code organization and reusability.';
 			break;
-		case 7:
+		case 8:
 			item.detail = 'state declaration';
 			item.documentation = 'Coco supports persistent and ephemeral state types.';
 			break;
-		case 8:
-			item.detail = 'persistent state';
-			item.documentation = 'Persistent state is the state of the module and ephemeral state refers to the state of the participant.';
-			break;
 		case 9:
+			item.detail = 'persistent state';
+			item.documentation = 'Persistent state is the state of the module.';
+			break;
+		case 10:
+			item.detail = 'ephemeral state';
+			item.documentation = 'Ephemeral state refers to the state of the participant.';
+			break;
+		case 11:
+			item.detail = 'readonly state';
+			item.documentation = 'Readonly state refers to functions with not state modifications.';
+			break;
+		case 12:
 			item.detail = 'class declaration';
 			item.documentation = 'Classes in Coco allows you to simplify the handling of complex structures. Each class is made up of fields and methods.';
 			break;
-		case 10:
+		case 13:
 			item.detail = 'method declaration';
 			item.documentation = 'Methods can be declared within the class block using the method keyword followed by the name of the method, input parameters and output parameters.';
 			break;
-		case 11:
+		case 14:
 			item.detail = 'module declaration';
 			item.documentation = 'The name of the module is one of Coco’s superglobals. It can be used to access the state information of the module as well as other information about the logic module.';
 			break;
-		case 12:
+		case 15:
 			item.detail = 'var declaration';
 			item.documentation = 'The var keyword is used to declare named variables with a specific type assigned in Coco';
 			break;
-		case 13:
+		case 16:
 			item.detail = 'const declaration';
 			item.documentation = 'The const keyword is used to declare named constant values of a specific type in Coco'
 		default:

--- a/server/src/modules/completion.ts
+++ b/server/src/modules/completion.ts
@@ -76,14 +76,19 @@ export const completionItems = (): CompletionItem[] => {
 			data: 14
 		},
 		{
-			label: 'var',
+			label: 'memory',
 			kind: CompletionItemKind.Text,
 			data: 15
 		},
 		{
-			label: 'const',
+			label: 'storage',
 			kind: CompletionItemKind.Text,
 			data: 16
+		},
+		{
+			label: 'const',
+			kind: CompletionItemKind.Text,
+			data: 17
 		},
 	]
 }
@@ -147,10 +152,14 @@ export const completionDetails = (item: CompletionItem): CompletionItem => {
 			item.documentation = 'The name of the module is one of Coco’s superglobals. It can be used to access the state information of the module as well as other information about the logic module.';
 			break;
 		case 15:
-			item.detail = 'var declaration';
-			item.documentation = 'The var keyword is used to declare named variables with a specific type assigned in Coco';
+			item.detail = 'memory declaration';
+			item.documentation = 'The memory keyword is used to declare named memory variables with a specific type assigned in Coco';
 			break;
 		case 16:
+			item.detail = 'storage declaration';
+			item.documentation = 'The memory keyword is used to declare named storage variables with a specific type assigned in Coco';
+			break;
+		case 17:
 			item.detail = 'const declaration';
 			item.documentation = 'The const keyword is used to declare named constant values of a specific type in Coco'
 		default:

--- a/server/src/modules/validation.ts
+++ b/server/src/modules/validation.ts
@@ -62,7 +62,7 @@ export const getCallableTypeMap = (text: String): Map<string, boolean> => {
 
 // statefulValidation ensures that endpoint type is persistent when mutation is performed
 export const statefulValidation = (text: string, diagnostics: Diagnostic[], typeMap: Map<string, boolean>) => {
-	const endpointPattern = /^(endpoint)\s+(invoke|enlist|deploy)\s+((persistent|readonly|ephemeral)\s+)?(\w+)/;
+	const endpointPattern = /^(endpoint)\s+(invoke)\s+((persistent|readonly|ephemeral)\s+)?(\w+)/;
 	const functionPattern = /^(func)\s+(persistent|readonly|ephemeral)\s+(\w+)/;
 	const lines = text.split(/\r?\n/);
 	
@@ -75,12 +75,12 @@ export const statefulValidation = (text: string, diagnostics: Diagnostic[], type
 		let callableName = null;
 		if (endpointMatch) {
 			callableName = endpointMatch[5];
-			hasPersistent = endpointMatch[4] == "persistent";
+			hasPersistent = (endpointMatch[4] == "persistent") || (endpointMatch[4] == "ephemeral");
 		}
 		
 		if(funcMatch){
 			callableName = funcMatch[3];
-			hasPersistent = funcMatch[2] == "persistent";
+			hasPersistent = (funcMatch[2] == "persistent") || (funcMatch[2] == "ephemeral");
 		}
 
 
@@ -91,7 +91,7 @@ export const statefulValidation = (text: string, diagnostics: Diagnostic[], type
 					start: { line: lineIndex, character: 0 },
 					end: { line: lineIndex, character: line.length }
 				},
-				message: `'${callableName}' is missing the 'persistent' stateful identifier while performing state modifications`,
+				message: `'${callableName}' is missing the a stateful identifier while performing state modifications`,
 				source: 'ex'
 			};
 			diagnostics.push(diagnostic);

--- a/server/src/modules/validation.ts
+++ b/server/src/modules/validation.ts
@@ -151,8 +151,15 @@ export const checkMutation = (text: string, diagnostics: Diagnostic[], mutateMap
 		if (mutateStatement) {
 			if(mutateStatement[1] && !mutateStatement[1].endsWith(":")){
 				let stateLoc  = mutateStatement[1].split(" ")[2]
-				if(stateLoc && stateLoc.split(".")[2]){
-					let location = stateLoc.split(".")[2]
+				let stateLocSplit = stateLoc.split(".")
+				if(stateLoc && stateLocSplit[1]){
+					let state = stateLocSplit[0]
+					let location = stateLocSplit[1]
+
+					if((state == "Sender" || state == "Receiver" || state == "State") && stateLoc.split(".")[2]){
+						location = stateLocSplit[2]
+					}
+
 					if(mutateMap.get(location)){
 						const diagnostic: Diagnostic = {
 							severity: DiagnosticSeverity.Error,
@@ -175,14 +182,16 @@ export const checkMutation = (text: string, diagnostics: Diagnostic[], mutateMap
 export const getCollections = (text: String): Map<string, boolean>=> {
 	let collectionMap: Map<string, boolean> = new Map();
 	const statePattern = /^(state)\s+(persistent)/;
+	const ephemeralPattern = /^(state)\s+(ephemeral)/;
 	const lines = text.split(/\r?\n/);
 	
 	for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
 		const line = lines[lineIndex];
 		const stateMatch = line.match(statePattern);
+		const ephemeralMatch = line.match(ephemeralPattern);
 		const typeDecPattern = /^(?!(\s*\/\/)).*/;
 
-		if(stateMatch){
+		if(stateMatch || ephemeralMatch){
 			// check all variables in the persistent state
 			for (let bodyLineIndex = lineIndex + 1; bodyLineIndex < lines.length; bodyLineIndex++) {
 				const bodyLine = lines[bodyLineIndex];

--- a/server/src/modules/validation.ts
+++ b/server/src/modules/validation.ts
@@ -5,23 +5,24 @@ import {
 
 // checkNames ensures that every callable's name begins with alphanumeric or underscore
 export const checkNames = (text: String, diagnostics: Diagnostic[]) => {
-	const endpointInvokablePattern = /^(endpoint)\s+(invokable)\s+(persistent|readonly)\s+(\w+)/;
-	const endpointDeployerPattern = /^(endpoint)\s+(deployer)\s+(\w+)/;
-	const functionPattern = /^(func)\s+(persistent|readonly)\s+(\w+)/;
+	const endpointPattern = /^(endpoint)\s+(invoke|enlist|deploy)\s+((persistent|ephemeral|readonly)\s+)?(\w+)/;
+	const functionPattern = /^(func)\s+(persistent|ephemeral|readonly)\s+(\w+)/;
 	const lines = text.split(/\r?\n/);
 
 	for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
 		const line = lines[lineIndex];
-		const patternMatch = line.match(endpointDeployerPattern) || line.match(endpointInvokablePattern) || line.match(functionPattern);
+		const patternMatch = line.match(endpointPattern) || line.match(functionPattern);
+		let callableName = ""
+
 		if (patternMatch){
-			let callableName = null;
-			if(patternMatch[1] == "func" || patternMatch[2] == "deployer"){
-				callableName = patternMatch[3];
-			}
-			if(patternMatch[1] == "endpoint" && patternMatch[2] == "invokable"){
-				callableName = patternMatch[4];
+			if(patternMatch[1]=="endpoint"){
+				 callableName = patternMatch[5];
 			}
 
+			if(patternMatch[1]=="func"){
+				callableName = patternMatch[3]
+			}
+			
 			if(callableName && !/^[A-Za-z_]/.test(callableName)){
 				const diagnostic: Diagnostic = {
 					severity: DiagnosticSeverity.Error,

--- a/server/src/modules/validation.ts
+++ b/server/src/modules/validation.ts
@@ -41,7 +41,7 @@ export const checkNames = (text: String, diagnostics: Diagnostic[]) => {
 
 // getCallableTypeMap obtains a map containing all persistent functions and endpoints
 export const getCallableTypeMap = (text: String): Map<string, boolean> => {
-	const statefulEndpoint = /^(endpoint)\s+(invokable)\s+(persistent)\s+(\w+)$/;
+	const statefulEndpoint = /^(endpoint)\s+(invoke)\s+(persistent)\s+(\w+)$/;
 	const statefulFunction = /^(func)\s+(persistent)\s+(\w+)/;
 	const lines = text.split(/\r?\n/);
 	let statefulMap: Map<string, boolean> = new Map();
@@ -62,8 +62,8 @@ export const getCallableTypeMap = (text: String): Map<string, boolean> => {
 
 // statefulValidation ensures that endpoint type is persistent when mutation is performed
 export const statefulValidation = (text: string, diagnostics: Diagnostic[], typeMap: Map<string, boolean>) => {
-	const endpointPattern = /^(endpoint)\s+(invokable)\s+(persistent|readonly)\s+(\w+)/;
-	const functionPattern = /^(func)\s+(persistent|readonly)\s+(\w+)/;
+	const endpointPattern = /^(endpoint)\s+(invoke|enlist|deploy)\s+((persistent|readonly|ephemeral)\s+)?(\w+)/;
+	const functionPattern = /^(func)\s+(persistent|readonly|ephemeral)\s+(\w+)/;
 	const lines = text.split(/\r?\n/);
 	
 	for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
@@ -74,8 +74,8 @@ export const statefulValidation = (text: string, diagnostics: Diagnostic[], type
 		let hasPersistent = false;
 		let callableName = null;
 		if (endpointMatch) {
-			callableName = endpointMatch[4];
-			hasPersistent = endpointMatch[3] == "persistent";
+			callableName = endpointMatch[5];
+			hasPersistent = endpointMatch[4] == "persistent";
 		}
 		
 		if(funcMatch){

--- a/server/src/modules/validation.ts
+++ b/server/src/modules/validation.ts
@@ -5,7 +5,7 @@ import {
 
 // checkNames ensures that every callable's name begins with alphanumeric or underscore
 export const checkNames = (text: String, diagnostics: Diagnostic[]) => {
-	const endpointPattern = /^(endpoint)\s+(invoke|enlist|deploy)\s+((persistent|ephemeral|readonly)\s+)?(\w+)/;
+	const endpointPattern = /^(endpoint)\s+(invoke|enlist|deploy)\s+((persistent|ephemeral|readonly)\s+)?(\w+\s*\([^)]*\):)/;
 	const functionPattern = /^(func)\s+(persistent|ephemeral|readonly)\s+(\w+)/;
 	const lines = text.split(/\r?\n/);
 

--- a/syntaxes/coco.tmLanguage.json
+++ b/syntaxes/coco.tmLanguage.json
@@ -148,7 +148,7 @@
             "patterns": [
                 {
                     "comment": "Callable Endpoints",
-                    "match": "^(endpoint)\\s+(invokable)\\s+(persistent|readonly)\\s+(\\w+)",
+                    "match": "^(endpoint)\\s+(invoke|enlist|deploy)\\s+(?:(ephemeral|persistent|readonly)\\s+)?(\\w+)",
                     "captures": {
                         "1": {
                             "name": "keyword.function.coco"
@@ -161,21 +161,6 @@
                             "name": "storage.modifier.state.coco"
                         },                       
                         "4": {
-                            "name": "entity.name.function.coco"
-                        }
-                    }
-                },
-                {
-                    "comment": "Deployer",
-                    "match": "^(endpoint)\\s+(deployer)\\s+(\\w+!?)\\(",
-                    "captures": {
-                        "1": {
-                            "name": "keyword.function.coco"
-                        },
-                        "2": {
-                            "name": "storage.modifier.func.coco"
-                        },
-                        "3": {
                             "name": "entity.name.function.coco"
                         }
                     }
@@ -257,6 +242,11 @@
                     "match": "\\b(field)\\b"
                 },
                 {
+                    "comment": "Topic Keyword",
+                    "name": "keyword.topic.coco",
+                    "match": "\\b(topic)\\b"
+                },
+                {
                     "comment": "Map Keyword",
                     "name": "keyword.map.coco",
                     "match": "\\b(Map)\\b"
@@ -272,6 +262,11 @@
                     "match": "\\b(state)\\b"
                 },
                 {
+                    "comment": "Event Keyword",
+                    "name": "keyword.event.coco",
+                    "match": "\\b(event)\\b"
+                },
+                {
                     "comment": "Crypto Builtins",
                     "name": "keyword.builtins.coco",
                     "match": "\\b(blake2b|keccak256|sha256|sigverify)\\b"
@@ -282,9 +277,14 @@
                     "match": "\\b(polorize|depolorize)\\b"
                 },
                 {
+                    "comment": "Collection Builtins",
+                    "name": "keyword.builtins.coco",
+                    "match": "\\b(grow|shrink)\\b"
+                },
+                {
                     "comment": "Special Methods",
                     "name": "keyword.special.coco",
-                    "match": "\\b(len|join)\\b"
+                    "match": "\\b(len|join|remove|emit)\\b"
                 }
             ]
         },
@@ -298,12 +298,15 @@
             "patterns": [
                 {
                     "comment": "Method declarations",
-                    "match": "\\b(method)\\b\\s+([A-Za-z_][A-Za-z0-9_!]*)",
+                    "match": "\\b(method)\\b\\s+(?:(mutate|observe)\\s+)?([A-Za-z_][A-Za-z0-9_!]*)",
                     "captures": {
                         "1": {
                             "name": "keyword.method.coco"
                         },
                         "2": {
+                            "name": "storage.modifier.state.coco"
+                        },
+                        "3": {
                             "name": "entity.name.function.coco"
                         }
                     }

--- a/syntaxes/coco.tmLanguage.json
+++ b/syntaxes/coco.tmLanguage.json
@@ -105,21 +105,6 @@
         "constants": {
             "patterns": [
                 {
-                    "name": "constant.declaration.coco",
-                    "match": "\\b(const)\\b\\s+((?:[a-zA-Z_][a-zA-Z0-9_]*\\s*,\\s*)*[a-zA-Z_][a-zA-Z0-9_]*)\\s+([a-zA-Z_][a-zA-Z0-9_]+\\b)?",
-                    "captures": {
-                        "1": { 
-                            "name": "keyword.const.coco" 
-                        },
-                        "2": {
-                            "name": "variable.other.declaration.coco"
-                        },
-                        "3": {
-                            "name": "storage.type.coco"
-                        }
-                    }
-                },
-                {
                     "comment": "Numeric Value Declaration",
                     "match": "\\b((0x[0-9a-fA-F]+)|(0[0-7]+i?)|(\\d+([Ee]\\d+)?i?)|(\\d+[Ee][-+]\\d+i?))\\b",
                     "name": "constant.numeric.coco"
@@ -285,6 +270,11 @@
                     "comment": "Special Methods",
                     "name": "keyword.special.coco",
                     "match": "\\b(len|join|remove|emit)\\b"
+                },
+                {
+                    "comment": "Type Declaration",
+                    "name": "keyword.types.coco",
+                    "match": "\\b(const|var)\\b"
                 }
             ]
         },

--- a/syntaxes/coco.tmLanguage.json
+++ b/syntaxes/coco.tmLanguage.json
@@ -214,7 +214,7 @@
                 {
                     "comment": "Action Keywords",
                     "name": "keyword.action.coco",
-                    "match": "\\b(observe|transfer|disperse|gather)\\b"
+                    "match": "\\b(observe|transfer|disperse|gather|generate)\\b"
                 },
                 {
                     "comment": "Exception Handling",
@@ -274,7 +274,7 @@
                 {
                     "comment": "Type Declaration",
                     "name": "keyword.types.coco",
-                    "match": "\\b(const|var)\\b"
+                    "match": "\\b(const|memory|storage)\\b"
                 }
             ]
         },
@@ -307,7 +307,7 @@
             "patterns": [
                 {
                     "comment": "Open/Closed State Access Statement",
-                    "match": "\\b(mutate|observe)\\b|(<-|->)\\s*|([A-Za-z_][A-Za-z0-9_]*)\\.(State|Sender|Receiver)\\s*",
+                    "match": "\\b(mutate|observe)\\b|(<-|->)\\s*|(State|Sender|Receiver)?\\.([A-Za-z_][A-Za-z0-9_]*)\\s*",
                     "captures": {
                         "1": {
                             "name": "keyword.state.coco"
@@ -316,10 +316,10 @@
                             "name": "keyword.operator.assignment.coco"
                         },
                         "3": {
-                            "name": "entity.name.contract.coco"
+                            "name": "support.variable.coco"
                         },
                         "4": {
-                            "name": "support.variable.coco"
+                            "name": "entity.name.contract.coco"
                         }
                     }
                 }

--- a/syntaxes/coco.tmLanguage.json
+++ b/syntaxes/coco.tmLanguage.json
@@ -183,7 +183,7 @@
             "patterns": [
                 {
                     "comment": "Function declarations",
-                    "match": "^(func)\\s+(persistent|readonly)\\s+(\\w+)",
+                    "match": "^(func)\\s+(?:(persistent|readonly)\\s+)?(\\w+)",
                     "captures": {
                         "1": {
                             "name": "keyword.function.coco"

--- a/syntaxes/coco.tmLanguage.json
+++ b/syntaxes/coco.tmLanguage.json
@@ -214,7 +214,7 @@
                 {
                     "comment": "Action Keywords",
                     "name": "keyword.action.coco",
-                    "match": "\\b(observe|transfer|disperse)\\b"
+                    "match": "\\b(observe|transfer|disperse|gather)\\b"
                 },
                 {
                     "comment": "Exception Handling",


### PR DESCRIPTION
## Description
- This PR adds support for ephemeral state operations and closes #11 
- Adds support for other features added in coco v0.5.0
- Updates versioning to support new changes

## Changes include
- Updates call qualifiers to invoke, enlist and deploy
- Adds state qualifiers to all endpoints
- Absence of state qualifier will now be treated as readonly
- Adds access qualifier requirement for class methods
- Updates language server to work with new state qualifiers for endpoints
- Updates language servers to provide completion for new keywords
- Stateful identifier now optional for deploy/enlist endpoints
- Ephemeral added to list of stateful identifiers

## Keywords added
- remove
- grow
- shrink
- emit
- event
- topic
- gather
- generate

