### PR TITLE
feature: add support for cocolang v0.6.0

### DIFF
--- a/server/src/modules/completion.ts
+++ b/server/src/modules/completion.ts
@@ -90,6 +90,26 @@ export const completionItems = (): CompletionItem[] => {
 			kind: CompletionItemKind.Text,
 			data: 17
 		},
+		{
+			label: 'logic',
+			kind: CompletionItemKind.Text,
+			data: 18
+		},
+		{
+			label: 'actor',
+			kind: CompletionItemKind.Text,
+			data: 19
+		},
+		{
+			label: 'dynamic',
+			kind: CompletionItemKind.Text,
+			data: 20
+		},
+		{
+			label: 'static',
+			kind: CompletionItemKind.Text,
+			data: 21
+		},
 	]
 }
 
@@ -137,7 +157,7 @@ export const completionDetails = (item: CompletionItem): CompletionItem => {
 			break;
 		case 11:
 			item.detail = 'readonly state';
-			item.documentation = 'Readonly state refers to functions with not state modifications.';
+			item.documentation = 'Readonly state refers to functions with no state modifications.';
 			break;
 		case 12:
 			item.detail = 'class declaration';
@@ -162,6 +182,22 @@ export const completionDetails = (item: CompletionItem): CompletionItem => {
 		case 17:
 			item.detail = 'const declaration';
 			item.documentation = 'The const keyword is used to declare named constant values of a specific type in Coco'
+		case 18:
+			item.detail = 'logic state';
+			item.documentation = 'Logic state is the state of the module.';
+			break;
+		case 19:
+			item.detail = 'actor state';
+			item.documentation = 'Actor state refers to the state of the participant.';
+			break;
+		case 9:
+			item.detail = 'dynamic state';
+			item.documentation = 'Dynamic state refers to changing actor or logic state';
+			break;
+		case 11:
+			item.detail = 'static state';
+			item.documentation = 'Static state refers to functions with no state modifications.';
+			break;
 		default:
 			break;
 	}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -90,7 +90,7 @@ documents.onDidClose(e => {
 // The content of a text document has changed. This event is emitted
 // when the text document first opened or when its content has changed.
 documents.onDidChangeContent(change => {
-	validateTextDocument(change.document);
+	//validateTextDocument(change.document);
 });
 
 async function validateTextDocument(textDocument: TextDocument): Promise<void> {

--- a/syntaxes/coco.tmLanguage.json
+++ b/syntaxes/coco.tmLanguage.json
@@ -133,7 +133,7 @@
             "patterns": [
                 {
                     "comment": "Callable Endpoints",
-                    "match": "^(endpoint)\\s+(invoke|enlist|deploy)\\s+(?:(ephemeral|persistent|readonly)\\s+)?(\\w+)",
+                    "match": "^(endpoint)\\s+(?:(invoke|enlist|deploy)\\s+)?(?:(ephemeral|persistent|readonly|static|dynamic)\\s+)?(\\w+)",
                     "captures": {
                         "1": {
                             "name": "keyword.function.coco"
@@ -141,10 +141,9 @@
                         "2": {
                             "name": "storage.modifier.func.coco"
                         },
-                        "3":
-                        {
+                        "3": {
                             "name": "storage.modifier.state.coco"
-                        },                       
+                        },
                         "4": {
                             "name": "entity.name.function.coco"
                         }
@@ -183,15 +182,14 @@
             "patterns": [
                 {
                     "comment": "Function declarations",
-                    "match": "^(func)\\s+(?:(persistent|readonly)\\s+)?(\\w+)",
+                    "match": "^(function)\\s+(?:(persistent|readonly|static|dynamic)\\s+)?(\\w+)",
                     "captures": {
                         "1": {
                             "name": "keyword.function.coco"
                         },
-                        "2":
-                        {
+                        "2": {
                             "name": "storage.modifier.state.coco"
-                        },                       
+                        },
                         "3": {
                             "name": "entity.name.function.coco"
                         }
@@ -372,9 +370,9 @@
                     "match": "\\b(String)\\b"
                 },
                 {
-                    "comment": "Address Value",
+                    "comment": "Identifier Value",
                     "name": "storage.type.address.coco",
-                    "match": "\\b(Address)\\b"
+                    "match": "\\b(Identifier)\\b"
                 },
                 {
                     "comment": "Boolean Value",
@@ -403,7 +401,7 @@
                 {
                     "comment": "State Type Definitions",
                     "name": "storage.modifier.state.coco",
-                    "match": "\\b(persistent|ephemeral)\\b"
+                    "match": "\\b(persistent|ephemeral|logic|actor)\\b"
                 }
             ]
         },
@@ -463,7 +461,7 @@
                 {
                     "comment": "Superglobal Keywords",
                     "name": "support.variable.coco",
-                    "match": "\\b(Ixn|Env|Sender|Receiver)\\b"
+                    "match": "\\b(Builtins|Invocation|Environment|Sender|Receiver)\\b"
                 }
             ]
         },


### PR DESCRIPTION
## Description
- This PR adds support for coco v0.6.0
- LSP validation disabled until 0.7.0 as Coco currently supports compilation to pisa0.3.2 and 0.4.0

## Changes include
- invoke/deploy/enlist now optional for all endpoints
- persistent/ephemral/readonly can now be replaced with just static/dynamic
- Ixn -> Invocation, Env -> Environment
- Builtins added to access new special functions
- state persistent/ephemeral renamed to state logic/actor




